### PR TITLE
Gem::Dependency#requirement

### DIFF
--- a/lib/jeweler/commands/check_dependencies.rb
+++ b/lib/jeweler/commands/check_dependencies.rb
@@ -10,7 +10,7 @@ class Jeweler
       def run
         missing_dependencies = dependencies.select do |dependency|
           begin
-            Gem.activate dependency.name, dependency.requirements.to_s
+            Gem.activate dependency.name, dependency.requirement.to_s
             false
           rescue LoadError => e
             true
@@ -22,7 +22,7 @@ class Jeweler
         else
           puts "Missing some dependencies. Install them with the following commands:"
           missing_dependencies.each do |dependency|
-            puts %Q{\tgem install #{dependency.name} --version "#{dependency.requirements.to_s}"}
+            puts %Q{\tgem install #{dependency.name} --version "#{dependency.requirement.to_s}"}
           end
 
           abort "Run the specified gem commands before trying to run this again: #{$0} #{ARGV.join(' ')}"


### PR DESCRIPTION
Fixes: 

undefined method `requirements' for #<Gem::Dependency:0x1014ce378>  
/opt/local/lib/ruby/gems/1.8/gems/jeweler-1.5.0.pre3/lib/jeweler/commands/check_dependencies.rb:13:in`run'  
/opt/local/lib/ruby/gems/1.8/gems/jeweler-1.5.0.pre3/lib/jeweler/commands/check_dependencies.rb:11:in `select'  
/opt/local/lib/ruby/gems/1.8/gems/jeweler-1.5.0.pre3/lib/jeweler/commands/check_dependencies.rb:11:in`run'  
/opt/local/lib/ruby/gems/1.8/gems/jeweler-1.5.0.pre3/lib/jeweler.rb:151:in `check_dependencies'  
/opt/local/lib/ruby/gems/1.8/gems/jeweler-1.5.0.pre3/lib/jeweler/tasks.rb:178:in`define'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:636:in `call'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:636:in`execute'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:631:in `each'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:631:in`execute'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:597:in `invoke_with_call_chain'  
/opt/local/lib/ruby/1.8/monitor.rb:242:in`synchronize'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:590:in `invoke_with_call_chain'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:607:in`invoke_prerequisites'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:604:in `each'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:604:in`invoke_prerequisites'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:596:in `invoke_with_call_chain'  
/opt/local/lib/ruby/1.8/monitor.rb:242:in`synchronize'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:590:in `invoke_with_call_chain'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:583:in`invoke'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:2051:in `invoke_task'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:2029:in`top_level'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:2029:in `each'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:2029:in`top_level'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:2068:in `standard_exception_handling'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:2023:in`top_level'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:2001:in `run'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:2068:in`standard_exception_handling'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake.rb:1998:in `run'  
/opt/local/lib/ruby/gems/1.8/gems/rake-0.8.7/bin/rake:31  
/opt/local/bin/rake:19:in`load'  
/opt/local/bin/rake:19
