### PR TITLE
Update cuke generator

### DIFF
--- a/features/generator/cucumber.feature
+++ b/features/generator/cucumber.feature
@@ -90,7 +90,7 @@ Feature: generating cucumber stories
     When I generate a rspec project named 'the-perfect-gem' that is 'zomg, so good'
 
     Then 'features/support/env.rb' requires 'the-perfect-gem'
-    And 'features/support/env.rb' requires 'spec/expectations'
+    And 'features/support/env.rb' requires 'rspec/expectations'
 
   Scenario: cucumber setup for mirconaut
     Given a working directory

--- a/lib/jeweler/generator/rspec_mixin.rb
+++ b/lib/jeweler/generator/rspec_mixin.rb
@@ -10,7 +10,7 @@ class Jeweler
       end
 
       def feature_support_require
-        'spec/expectations'
+        'rspec/expectations'
       end
 
       def feature_support_extend

--- a/test/jeweler/test_generator.rb
+++ b/test/jeweler/test_generator.rb
@@ -93,7 +93,7 @@ class TestGenerator < Test::Unit::TestCase
     should_have_generator_attribute :test_task, 'spec'
     should_have_generator_attribute :test_dir, 'spec'
     should_have_generator_attribute :default_task, 'spec'
-    should_have_generator_attribute :feature_support_require, 'spec/expectations'
+    should_have_generator_attribute :feature_support_require, 'rspec/expectations'
     should_have_generator_attribute :feature_support_extend, nil
     should_have_generator_attribute :test_pattern, 'spec/**/*_spec.rb'
     should_have_generator_attribute :test_filename, 'the-perfect-gem_spec.rb'


### PR DESCRIPTION
The cucumber env.rb template was generating the old 'spec/expectations' require. Modified rspec_mixin.rb to write out the new 'rspec/expectations' like.  Updated feature and test as well.
