### PR TITLE
Multiple Version Requirements in Gemfile

### DIFF
--- a/lib/jeweler/specification.rb
+++ b/lib/jeweler/specification.rb
@@ -79,10 +79,10 @@ class Jeweler
           require 'bundler'
           bundler = Bundler.load
           bundler.dependencies_for(:default, :runtime).each do |dependency|
-            self.add_dependency dependency.name, dependency.requirement.to_s
+            self.add_dependency dependency.name, *dependency.requirement.as_list
           end
           bundler.dependencies_for(:development).each do |dependency|
-            self.add_development_dependency dependency.name, dependency.requirement.to_s
+            self.add_development_dependency dependency.name, *dependency.requirement.as_list
           end
         end
         


### PR DESCRIPTION
Heya Josh

I just added a multiple version requirement to Thinking Sphinx's Gemfile (the same one I'd had in my Jeweler gemspec definition), and hit a similar issue - it's fine at checking dependencies, but not at building the gemspec via Gemfile. This patch makes things happy again :)

Hopefully it's not too late for the 1.5.0 proper release. 
