### PR TITLE
Redcar ignore

### DIFF
--- a/lib/jeweler/templates/.gitignore
+++ b/lib/jeweler/templates/.gitignore
@@ -40,3 +40,6 @@ pkg
 #
 # For vim:
 #*.swp
+
+# For redcar:
+#.redcar


### PR DESCRIPTION
Hi,

You are missing the .redcar directory in the .gitignore template. Since Redcar is an insanely cool editor (ruby built, acts_as_textmate, etc) I though it should be provided, if only to generate awareness.

Since I only updated the .gitignore template I could device no sane spec/test. I hope I am forgiven...

The tests all applied with:

```
  * DEFERRED: release_tagged? when no tag exists should be true. 
  * DEFERRED: release_tagged? when tag exists should be false. 
  * DEFERRED: release_tagged? when no tag exists should be true. 
  * DEFERRED: release_tagged? when tag exists should be false. 
  * DEFERRED: after run should output that the gemspec was written. 
Loaded suite /opt/ruby-enterprise-1.8.7-2010.01/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake/rake_test_loader
Started
.............................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 1.996258 seconds.

397 tests, 357 assertions, 0 failures, 0 errors
```

Thank you for making jeweler and have a great day!

Kind regards,
Hartog de Mik
