### PR TITLE
a patch to accept UTF-8 String in Rakefile on Ruby 1.9

### DIFF
--- a/lib/jeweler/templates/Rakefile
+++ b/lib/jeweler/templates/Rakefile
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'rubygems'
 <%= render_template 'bundler_setup.erb' %>
 require 'rake'


### PR DESCRIPTION
This patch is for #20
Though this patch enables to run multibyteish Rakefile on Ruby 1.9, I think the original problem will still remain on 1.8.
I guess the root cause is in Rubygems (and Yaml, maybe), and I will work on it later.
