### PR TITLE
Optional github integration (--[no-]github support)

### DIFF
--- a/lib/jeweler/generator.rb
+++ b/lib/jeweler/generator.rb
@@ -57,10 +57,18 @@ class Jeweler
 
     def initialize(options = {})
       self.options = options
+      extracted_directory = nil
 
       self.project_name   = options[:project_name]
       if self.project_name.nil? || self.project_name.squeeze.strip == ""
         raise NoGitHubRepoNameGiven
+      else
+        path = File.split(self.project_name)
+
+        if path.size > 1
+          extracted_directory = File.join(path[0..-1])
+          self.project_name = path.last
+        end
       end
 
       self.development_dependencies = []
@@ -82,7 +90,7 @@ class Jeweler
         raise ArgumentError, "Unsupported documentation framework (#{documentation_framework})"
       end
 
-      self.target_dir             = options[:directory] || self.project_name
+      self.target_dir             = options[:directory] || extracted_directory || self.project_name
 
       self.summary                = options[:summary] || 'TODO: one-line summary of your gem'
       self.description            = options[:description] || 'TODO: longer description of your gem'

--- a/lib/jeweler/generator/options.rb
+++ b/lib/jeweler/generator/options.rb
@@ -10,6 +10,8 @@ class Jeweler
         self[:testing_framework]       = :shoulda
         self[:documentation_framework] = :rdoc
         self[:use_bundler]             = true
+        self[:use_github]              = true
+        self[:create_repo]             = false
 
         git_config =  if Pathname.new("~/.gitconfig").expand_path.exist?
                         Git.global_config
@@ -71,6 +73,10 @@ class Jeweler
 
           o.on('--[no-]bundler', 'use bundler for managing dependencies') do |v|
             self[:use_bundler] = v
+          end
+
+          o.on('--[no-]github', 'prepare project for github integration') do |v|
+            self[:use_github] = v
           end
 
           o.on('--cucumber', 'generate cucumber stories in addition to the other tests') do

--- a/test/jeweler/test_generator.rb
+++ b/test/jeweler/test_generator.rb
@@ -2,12 +2,14 @@ require 'test_helper'
 
 class TestGenerator < Test::Unit::TestCase
   def build_generator(testing_framework = :shoulda, options = {})
-    options = options.merge :project_name => 'the-perfect-gem',
-                            :user_name => 'John Doe',
-                            :user_email => 'john@example.com',
-                            :github_username => 'johndoe',
-                            :github_token => 'yyz',
-                            :documentation_framework => :rdoc
+    options = {
+      :project_name => 'the-perfect-gem',
+      :user_name => 'John Doe',
+      :user_email => 'john@example.com',
+      :github_username => 'johndoe',
+      :github_token => 'yyz',
+      :documentation_framework => :rdoc
+    }.merge(options)
 
     options[:testing_framework] = testing_framework
     Jeweler::Generator.new(options)
@@ -32,6 +34,18 @@ class TestGenerator < Test::Unit::TestCase
   should "have the correct git-remote" do
     assert_equal 'user@host:/path/to/repo', build_generator(:shoulda, {:git_remote => "user@host:/path/to/repo"}).git_remote
     assert_equal 'git@github.com:johndoe/the-perfect-gem.git', build_generator.git_remote 
+  end
+
+  should "extract project name from absolut path" do
+    assert_equal "my-project", build_generator(:shoulda, {:project_name => "/tmp/my-project"}).project_name
+  end
+
+  should "extract project name from relative path" do
+    assert_equal "my-project", build_generator(:shoulda, {:project_name => "../my-project"}).project_name
+  end
+
+  should "extract project name from direct path" do
+    assert_equal "my-project", build_generator(:shoulda, {:project_name => "my-project"}).project_name
   end
 
   def self.should_have_generator_attribute(attribute, value)

--- a/test/jeweler/test_generator_initialization.rb
+++ b/test/jeweler/test_generator_initialization.rb
@@ -101,7 +101,7 @@ class TestGeneratorInitialization < Test::Unit::TestCase
     end
 
     should "set target directory to the project name" do
-      assert_equal @project_name, @generator.target_dir
+      assert_equal @project_name, File.split(@generator.target_dir).last
     end
 
     should "set user's name from git config" do

--- a/test/jeweler/test_generator_initialization.rb
+++ b/test/jeweler/test_generator_initialization.rb
@@ -161,4 +161,18 @@ class TestGeneratorInitialization < Test::Unit::TestCase
 
   end
 
+  context "disabling github integration" do
+    setup do
+      @generator = build_generator(:use_github => false)
+      stub_git_config
+    end
+
+    should "not set git_remote" do
+      assert_nil @generator.git_remote
+    end
+
+    should "not fail on getting git username" do
+      build_generator(:use_github => false, :github_username => nil)
+    end
+  end
 end


### PR DESCRIPTION
This patch allows the user to create a jeweler project structure without having any git(+hub) integration. I've added the option in a way the tool still behaves in the original way and tries to add fully github support, so it should provide full backward compatibility.

To disable github support the user just has to apply the --no-github option.