### PR TITLE
Need to require rubygems for ruby 1.8

### DIFF
--- a/bin/jeweler
+++ b/bin/jeweler
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+#require 'rubygems' if RUBY_VERSION < '1.9'
 require 'jeweler/generator'
 
 exit Jeweler::Generator::Application.run!(*ARGV)


### PR DESCRIPTION
Still need to require rubygems for ruby 1.8 compatibility

<pre>
ruby --version
ruby 1.8.7 (2011-06-30 patchlevel 352) [i686-darwin11.2.0]


bin/jeweler 
./bin/../lib/jeweler/generator.rb:1:in `require': no such file to load -- git (LoadError)
    from ./bin/../lib/jeweler/generator.rb:1
    from bin/jeweler:4:in `require'
    from bin/jeweler:4

</pre>
