### PR TITLE
Use Gem::Package.build(spec) instead of Gem::Builder.new(spec).build

### DIFF
--- a/lib/jeweler.rb
+++ b/lib/jeweler.rb
@@ -11,6 +11,7 @@ require 'jeweler/version'
 class Jeweler
   require 'jeweler/errors'
   require 'rubygems/user_interaction'
+  require 'rubygems/package'
 
   autoload :Generator,      'jeweler/generator'
 

--- a/lib/jeweler/commands/build_gem.rb
+++ b/lib/jeweler/commands/build_gem.rb
@@ -12,8 +12,7 @@ class Jeweler
 
         gemspec = gemspec_helper.parse
 
-        require 'rubygems/builder'
-        gem_file_name = Gem::Builder.new(gemspec).build
+        gem_file_name = Gem::Package.build(gemspec)
 
         pkg_dir = File.join(base_dir, 'pkg')
         file_utils.mkdir_p pkg_dir

--- a/test/jeweler/commands/test_build_gem.rb
+++ b/test/jeweler/commands/test_build_gem.rb
@@ -23,8 +23,7 @@ class Jeweler
         end
 
         should "build from parsed gemspec" do
-          assert_received(Gem::Builder) {|builder_class| builder_class.new(@gemspec) }
-          assert_received(@builder) {|builder| builder.build }
+          assert_received(Gem::Package) {|builder_class| builder_class.build(@gemspec) }
         end
 
         should 'make package directory' do
@@ -82,8 +81,7 @@ class Jeweler
         @version_helper = "Jeweler::VersionHelper"
 
         @builder = Object.new
-        stub(Gem::Builder).new { @builder }
-        stub(@builder).build { 'zomg-1.2.3.gem' }
+        stub(Gem::Package).build { 'zomg-1.2.3.gem' }
 
         @file_utils = Object.new
         stub(@file_utils).mkdir_p './pkg'


### PR DESCRIPTION
Jeweler can't build gems after RubyGems 2.0.0 update. 

From RubyGems ReleaseNotes : 

> - Merged Gem::Builder into Gem::Package. Use Gem::Package.build(spec)
>   instead of Gem::Builder.new(spec).build
