### PR TITLE
Bump version number

### DIFF
--- a/lib/jeweler/version.rb
+++ b/lib/jeweler/version.rb
@@ -2,7 +2,7 @@ class Jeweler
   module Version
     MAJOR = 1
     MINOR = 8
-    PATCH = 4
+    PATCH = 7
     BUILD = nil
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')


### PR DESCRIPTION
The current gem is version 1.8.6 but when you run

```
jeweler -v
```

it reports 1.8.4. This can be very confusing when trying to debug things (it left me installing and uninstalling a few different versions before I realised the problem).
