### PR TITLE
Use a version of timecop that supports Ruby 1.8.7 and wasn't yanked :/

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development do
 end
 
 group :test do
-  gem "timecop", "~> 0.6.2"
+  gem "timecop", "0.6.1"
   gem "activesupport", "~> 2.3.5"
   gem "shoulda"
   gem "mhennemeyer-output_catcher"


### PR DESCRIPTION
`timecop` bumped Ruby version dependency to Ruby 1.9 in version `0.6.2.2` and yanked `0.6.2` . 
