### PR TITLE
Fix URL of build status badge

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ Jeweler provides the noble ruby developer with two primary features:
  * a library for managing and releasing RubyGem projects
  * a scaffold generator for starting new RubyGem projects
 
-[![Build Status](https://secure.travis-ci.org/technicalpickles/jeweler.png)](http://travis-ci.org/technicalpickles/jeweler])
+[![Build Status](https://travis-ci.org/technicalpickles/jeweler.png)](https://travis-ci.org/technicalpickles/jeweler)
 
 ## Hello, world
 


### PR DESCRIPTION
Removed the stray `]` in the build status badge URL
