### PR TITLE
Alternative implementation of a --no-github option

### DIFF
--- a/lib/jeweler/generator.rb
+++ b/lib/jeweler/generator.rb
@@ -51,7 +51,7 @@ class Jeweler
                   :description, :project_name, :github_username,
                   :repo, :should_create_remote_repo, 
                   :testing_framework, :documentation_framework,
-                  :should_use_cucumber, :should_use_bundler,
+                  :should_use_cucumber, :should_use_bundler, :should_use_github,
                   :should_setup_rubyforge, :should_use_reek, :should_use_roodi,
                   :development_dependencies,
                   :options,
@@ -101,6 +101,8 @@ class Jeweler
       self.should_use_roodi       = options[:use_roodi]
       self.should_setup_rubyforge = options[:rubyforge]
       self.should_use_bundler     = options[:use_bundler]
+      self.should_use_github      = !options[:no_github]
+
 
       development_dependencies << ["cucumber", ">= 0"] if should_use_cucumber
 
@@ -118,8 +120,8 @@ class Jeweler
       
       self.git_remote      = options[:git_remote]
 
-      raise NoGitUserName unless self.user_name
-      raise NoGitUserEmail unless self.user_email
+      raise NoGitUserName unless self.user_name if self.should_use_github
+      raise NoGitUserEmail unless self.user_email if self.should_use_github
 
       extend GithubMixin
     end

--- a/lib/jeweler/generator/github_mixin.rb
+++ b/lib/jeweler/generator/github_mixin.rb
@@ -4,8 +4,8 @@ class Jeweler
       def self.extended(generator)
         generator.github_username           = generator.options[:github_username]
         generator.should_create_remote_repo = generator.options[:create_repo]
-
-        unless generator.github_username
+        
+        if generator.should_use_github && !generator.github_username
           raise NoGitHubUser
         end
       end

--- a/lib/jeweler/generator/options.rb
+++ b/lib/jeweler/generator/options.rb
@@ -10,6 +10,7 @@ class Jeweler
         self[:testing_framework]       = :shoulda
         self[:documentation_framework] = :rdoc
         self[:use_bundler]             = true
+        self[:no_github]               = false
 
         self[:user_name]       = ENV['GIT_AUTHOR_NAME']  || ENV['GIT_COMMITTER_NAME']  || git_config['user.name']
         self[:user_email]      = ENV['GIT_AUTHOR_EMAIL'] || ENV['GIT_COMMITTER_EMAIL'] || git_config['user.email']
@@ -118,6 +119,10 @@ class Jeweler
 
           o.on('--create-repo', 'create the repository on GitHub') do
             self[:create_repo] = true
+          end
+
+          o.on('--no-github', 'do not use github for the remote repository') do
+            self[:no_github] = true
           end
 
 

--- a/test/jeweler/generator/test_options.rb
+++ b/test/jeweler/generator/test_options.rb
@@ -58,6 +58,10 @@ class TestOptions < Test::Unit::TestCase
     should "use bundler" do
       assert @options[:use_bundler]
     end
+
+    should "use github" do 
+      assert !@options[:no_github]
+    end
   end
 
   for_options "--bacon" do
@@ -207,6 +211,12 @@ class TestOptions < Test::Unit::TestCase
   for_options '--no-bundler' do
     should "not use bundler" do
       assert !@options[:use_bundler]
+    end
+  end
+
+  for_options '--no-github' do
+    should "not use github" do
+      assert @options[:no_github]
     end
   end
 

--- a/test/jeweler/test_generator_initialization.rb
+++ b/test/jeweler/test_generator_initialization.rb
@@ -147,4 +147,22 @@ class TestGeneratorInitialization < Test::Unit::TestCase
 
   end
 
+  context "without using GitHub" do 
+    setup do
+      stub_git_config
+    end
+
+    should "create a git repo without git user name" do 
+      assert_nothing_raised Jeweler::NoGitUserName do
+        @generator = build_generator(no_github: true, user_name: nil)
+      end
+    end
+
+    should "create a git repo without git user email" do 
+      assert_nothing_raised Jeweler::NoGitUserEmail do
+        @generator = build_generator(no_github: true, user_email: nil)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This PR adds support for a `--no-github` option to the `jeweler` command, which enables a user to create a gem project using Jeweler without requiring GitHub for a remote repository. When the `--no-github` flag is not set, the functionality of the `jeweler` command is unchanged; this PR does not introduce any breaking changes.

Unlike #186, this PR does not conflate 'no GitHub' and 'no Git.' Thus, using the `--no-github` option will still create a Git repo. Adding support for a `--no-git` flag could be added separately, as discussed in #186.

Usage:

```sh
jeweler --no-github the-perfect-gem
```

which will create a new gem project `the-perfect-gem` with an initialized Git repo, without a remote repository configured.

This PR also includes several tests for the new functionality.