### PR TITLE
fix: obsolete SAFE level breaking gem on ruby 2.3.0

### DIFF
--- a/lib/jeweler/gemspec_helper.rb
+++ b/lib/jeweler/gemspec_helper.rb
@@ -48,7 +48,7 @@ class Jeweler
     def parse
       data = self.to_ruby
       parsed_gemspec = nil
-      Thread.new { parsed_gemspec = eval("$SAFE = 3\n#{data}", binding, path) }.join
+      Thread.new { parsed_gemspec = eval("$SAFE = 1\n#{data}", binding, path) }.join
       parsed_gemspec
     end
 


### PR DESCRIPTION
hi jeweler, 

this pull should fix issue #278 

levels 2-4 are obsolete... 1 should be "safe" enough, according to http://phrogz.net/programmingruby/taint.html

some related info on SAFE 2-4 being removed:
https://bugs.ruby-lang.org/issues/8468
https://bugs.ruby-lang.org/issues/11908

enjoy