### PR TITLE
Backport Bunder::Runtime#dependencies_for

### DIFF
--- a/lib/jeweler/specification.rb
+++ b/lib/jeweler/specification.rb
@@ -69,10 +69,11 @@ class Jeweler
 
         if File.exist?('Gemfile')
           require 'bundler'
-          Bundler.require(:default, :runtime).each do |dependency|
+          bundler_runtime = Bundler.load
+          bundler_dependencies_for(bundler_runtime, :default, :runtime).each do |dependency|
             add_dependency dependency.name, *dependency.requirement.as_list
           end
-          Bundler.require(:development).each do |dependency|
+          bundler_dependencies_for(bundler_runtime, :development).each do |dependency|
             add_development_dependency dependency.name, *dependency.requirement.as_list
           end
         end
@@ -88,6 +89,18 @@ class Jeweler
     end
 
     private
+
+    # Backported (or rather forward-ported) from Bunder::Runtime#dependencies_for.
+    # This method was available until Bundler 1.13, and then removed. We need it
+    # to be able to tell which gems are listed in the Gemfile without loading
+    # those gems first.
+    def bundler_dependencies_for(bundler_runtime, *groups)
+      if groups.empty?
+        bundler_runtime.dependencies
+      else
+        bundler_runtime.dependencies.select {|d| (groups & d.groups).any? }
+      end
+    end
 
     def blank?(value)
       value.nil? || value.empty?


### PR DESCRIPTION
to have it also when running under Bundler 1.13+.

Fixes issue #289, supersedes PRs #290 #291.